### PR TITLE
Moderator email notifications

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -32,7 +32,7 @@ def add_event():
     if request.method == "POST" and form.validate_on_submit():
         inserted_event = db.create_new_event(form.data)
         email.send_submission_confirmation(request.base_url, inserted_event)
-        email.notify_moderator_new_event("test", inserted_event, "frankscalendar.olin@gmail.com")
+        email.notify_moderator_new_event("test", inserted_event, "frankscalendar@olin.edu")
         return redirect(
             url_for('public.confirmation',
                 event_id=inserted_event['_id'],
@@ -83,7 +83,7 @@ def edit_event(event_id):
         inserted_event = db.update_event(event_id, form.data)
         event_data = db.get_one(ObjectId(event_id))
         if event_data["status"] == Status.APPROVED.value:
-            email.notify_moderator("test", event_data, "frankscalendar.olin@gmail.com")
+            email.notify_moderator("test", event_data, "frankscalendar@olin.edu")
             #if the event was already approved, send an email to everyone who may have exported and ical of the event
             emails = event_data.get("shared_emails")
             if emails:

--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -32,6 +32,7 @@ def add_event():
     if request.method == "POST" and form.validate_on_submit():
         inserted_event = db.create_new_event(form.data)
         email.send_submission_confirmation(request.base_url, inserted_event)
+        email.notify_moderator_new_event("test", inserted_event, "frankscalendar.olin@gmail.com")
         return redirect(
             url_for('public.confirmation',
                 event_id=inserted_event['_id'],

--- a/modules/sg_client.py
+++ b/modules/sg_client.py
@@ -24,12 +24,12 @@ class EmailClient(object):
         ).client
         return self._client
 
-    
+
     def send_email(self, subject, message, recipient, attachments=None, ismultiple=False):
             mail = Mail(
                 from_email="frankscalendar@olin.edu",
-                html_content=message, 
-                subject=subject,     
+                html_content=message,    
+                subject=subject,
                 )
 
             personalize = Personalization()
@@ -143,6 +143,32 @@ class EmailClient(object):
             host_email=event['host_email'])
         
         self.send_email("A published event was updated", content, moderator) 
+
+    def notify_moderator_new_event(self, code, event, moderator):
+        # if event was modified after the moderator already approved it, an email will notify the moderator of changes
+        editlink = "calendar.olin.build/admin?code=" + code
+        approve_link="calendar.olin.build/approve/{id}?magic={magic}".format(id=event['_id'], magic=event['magic'])
+        request_changes_link="calendar.olin.build/request_changes/{id}?magic={magic}".format(id=event['_id'], magic=event['magic'])
+        cancel_event_link="calendar.olin.build/cancel_event/{id}?magic={magic}&email=yes".format(id=event['_id'], magic=event['magic'])
+        
+        path = os.getcwd() + "/templates/emails/notify_moderator_new_event.txt"
+        template = Template(open(path).read())
+
+        content = template.render(
+            link=editlink,
+            title=event['title'],
+            location=event['location'],
+            dtstart=event['dtstart'],
+            dtend=event['dtend'],
+            description=event['description'],
+            host=event['host_name'],
+            host_email=event['host_email'],
+            approve_link=approve_link,
+            request_changes_link=request_changes_link,
+            cancel_event_link=cancel_event_link
+        )
+
+        self.send_email("An event was created", content, moderator)
 
     def generate_edit_link(self, base, event):
         magic = str(event['magic'])

--- a/templates/emails/notify_moderator_new_event.txt
+++ b/templates/emails/notify_moderator_new_event.txt
@@ -1,0 +1,19 @@
+Hi Moderator! 
+<br><br>
+Event {{title}} was created today. The event information now consists of: 
+<br><br>
+Title: {{title}}<br>
+Host: {{host}}, {{host_email}}<br>
+When: {{dtstart}} to {{dtend}}<br>
+Where: {{location}}<br>
+What: {{description}}
+<br><br>    
+If changes were not appropriate, cancel the event via this <a href=http://{{link}}>magic link</a> .
+<br><br>
+Quick Links:<br>
+<a href=http://{{approve_link}}>approve link</a><br>
+<a href=http://{{request_changes_link}}>request changes link</a><br>
+<a href=http://{{cancel_event_link}}>cancel event link</a><br>
+<br>
+Sincerely, <br>
+Frank's Calendar

--- a/templates/emails/notify_moderator_new_event.txt
+++ b/templates/emails/notify_moderator_new_event.txt
@@ -8,12 +8,12 @@ When: {{dtstart}} to {{dtend}}<br>
 Where: {{location}}<br>
 What: {{description}}
 <br><br>    
-If changes were not appropriate, cancel the event via this <a href=http://{{link}}>magic link</a> .
+If changes were not appropriate, request changes via this <a href=http://{{link}}>magic link</a> .
 <br><br>
 Quick Links:<br>
-<a href=http://{{approve_link}}>approve link</a><br>
-<a href=http://{{request_changes_link}}>request changes link</a><br>
-<a href=http://{{cancel_event_link}}>cancel event link</a><br>
+<a href=http://{{approve_link}}>approve link</a><br><br>
+<a href=http://{{request_changes_link}}>request changes link</a><br><br>
+<a href=http://{{cancel_event_link}}>cancel event link</a><br><br>
 <br>
 Sincerely, <br>
 Frank's Calendar


### PR DESCRIPTION
[Moderator email notifications](https://app.asana.com/0/1190853173158033/1190853173158076/f)
- Anytime a new event is submitted, they should receive an email notifying them of a new event
- From the email, they have the option of “approving”, “requesting changes”, or “cancelling” the event via links (functionality should be as below)

![Screenshot from 2020-09-07 13-52-08](https://user-images.githubusercontent.com/40768833/92410291-ac8ed000-f111-11ea-9bfd-5371e885d1d2.png)

- also, changed moderator email from "frankscalendar.olin@gmail.com" to "frankscalendar@olin.edu" for /edit/ route too