### PR TITLE
Correct usage of flexbox to fix header display problems on Safari

### DIFF
--- a/static/css/index.scss
+++ b/static/css/index.scss
@@ -51,11 +51,10 @@
 .Header {
     padding: 0.35rem 1rem;
     display: flex;
-    flex: 0 1 0;
+    flex: 0 0 auto;
     align-items: center;
     justify-content: space-between;
     box-shadow: 0.1rem 0.1rem 0.25rem $secondary;
-    flex: 0 1 0;
 
     &__title {
       font-family: $title;
@@ -245,6 +244,7 @@
   min-width: 60em; 
   max-width: 70em;
   padding: 0em 1em 0em 1em;
+  flex: 0 0 auto;
 
   color: $main;
   font-family: $sans;
@@ -552,8 +552,7 @@
     font-weight: 600;
     text-align: center;
     padding: 1rem 1rem;
-    position: sticky;
-    bottom: -999rem;
+    flex: 0 0 auto;
 
     &__message {
         display: block;


### PR DESCRIPTION
I'm honestly not sure why this didn't affect more browsers, but it's fixed.

## Before
<img width="1125" alt="Screen Shot 2020-09-16 at 9 10 35 AM" src="https://user-images.githubusercontent.com/3915596/93341763-7e3d7e80-f7fc-11ea-8bf5-735ad826f194.png">


## After
<img width="1123" alt="Screen Shot 2020-09-16 at 9 09 12 AM" src="https://user-images.githubusercontent.com/3915596/93341596-50583a00-f7fc-11ea-895a-cb4a1d8d73fa.png">
